### PR TITLE
Add print_p option

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -33,9 +33,9 @@
              , print_call   = true         % print calls (see `return_only')
              , print_form   = "~s~n"       % format for printing
 	     , print_file   = ""           % file to print to (standard_io)
+             , print_msec   = false        % print milliseconds in timestamps?
              , print_p      = 999999       % Limit for "~P" formatting depth
              , print_re     = ""           % regexp that must match to print
-             , print_msec   = false        % print milliseconds in timestamps?
 	     , max_queue    = 5000         % max # of msgs before suicide
 	     , max_msg_size = 50000        % max message size before suicide
              , file         = ""           % file to write trace msgs to
@@ -99,9 +99,9 @@ help() ->
            , "buffered     (no)          buffer messages till end of trace"
            , "print_form   (\"~s~n\")      print msgs using this format"
            , "print_file   (standard_io) print to this file"
+           , "print_msec   (false)       print milliseconds on timestamps"
            , "print_p      (999999)      formatting depth for \"~P\""
            , "print_re     (\"\")          print only strings that match this"
-           , "print_msec   (false)       print milliseconds on timestamp"
            , "  trc file related opts"
            , "file         (none)        use a trc file based on this name"
            , "file_size    (1)           size of each trc file"


### PR DESCRIPTION
Hi, Mats.  I've a couple of eper formatting options that I'd thought had been sent to you back in the SourceForge days, but perhaps I'm wrong.
1. Add the print_p option to print possibly-big terms using ~P instead of ~p.
2. Add the print_msec option to append milliseconds to formatted timestamps.

Both patches are small & perhaps ought to be on separate feature branches ... except that they both mangle functions like printi(), so clean patching wouldn't be so easy?  {shrug}
