### PR TITLE
Relax check on consumers to support parameterised modules

### DIFF
--- a/src/prfHost.erl
+++ b/src/prfHost.erl
@@ -22,7 +22,7 @@
 
 start(Name,Node,Consumer) -> start(Name,Node,Consumer,no_proxy).
 start(Name,Node,Consumer,Proxy)
-  when is_atom(Name),is_atom(Node),is_atom(Consumer),is_atom(Proxy) ->
+  when is_atom(Name),is_atom(Node), is_atom(Proxy) ->
   assert_proxy(Proxy),
   SpawnFun = fun()->init(Consumer,Node,Proxy) end,
   case whereis(Name) of


### PR DESCRIPTION
Parameterised modules aren't the best thing in the world, but for a dynamic consumer (e.g., one where you wish to construct the `collectors` at runtime) they're quite useful. This patch relaxes the `is_atom/1` check on consumers in `prfHost` so that they can be used.
