### PR TITLE
sherk_ets:f2t/3 not tail recursive

### DIFF
--- a/src/sherk_ets.erl
+++ b/src/sherk_ets.erl
@@ -121,9 +121,8 @@ get_tab_header(FD) ->
 
 
 f2t(FD,Tab,N) ->
-  try
-    ets:insert(Tab,f2t_f(FD)),
-    f2t(FD,Tab,N+1)
+  try ets:insert(Tab,f2t_f(FD)) of
+    _ -> f2t(FD,Tab,N+1)
   catch
     throw:delimiter -> N;
     throw:eof -> exit({unexpected_eof})


### PR DESCRIPTION
Bugfix: sherk_ets:f2t/3 was not tail recursive because of an exception handler.
