### PR TITLE
Remove crypto module deprecations

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,20 @@
+%% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
+%% vim: set ft=erlang ts=2 sw=2:
+
+WhenExportedDefine = fun ({M, F, Arity}, Define, Opts) ->
+  case erlang:function_exported(M, F, Arity) of
+    true  -> [{d, Define} | Opts];
+    false -> Opts
+  end
+end,
+ExtractErlOpts = fun (Cfg) ->
+  case lists:keyfind(erl_opts, 1, CONFIG) of
+    {erl_opts, Opts} -> Opts;
+    false            -> []
+  end
+end,
+ErlOpts0 = ExtractErlOpts(CONFIG),
+code:ensure_loaded(crypto),
+ErlOpts1 = WhenExportedDefine({crypto, block_encrypt, 4}, 'USE_CRYPTO_BLOCK_CRYPT', ErlOpts0),
+ErlOpts2 = WhenExportedDefine({crypto, hash, 2}, 'USE_CRYPTO_HASH', ErlOpts1),
+lists:keyreplace(erl_opts, 1, CONFIG, {erl_opts, ErlOpts2}).

--- a/src/prf_crypto.erl
+++ b/src/prf_crypto.erl
@@ -8,6 +8,24 @@
 -author('Mats Cronqvist').
 -export([encrypt/1,encrypt/2,decrypt/1,decrypt/2]).
 
+-ifdef(USE_CRYPTO_HASH).
+-define(CRYPTO_HASH(Data), crypto:hash(md5, Data)).
+-else.
+-define(CRYPTO_HASH(Data), crypto:md5(Data)).
+-endif.
+
+-ifdef(USE_CRYPTO_BLOCK_CRYPT).
+-define(CRYPTO_BLOCK_ENCRYPT(Key, IVec, Text),
+  crypto:block_encrypt(des_cbc, Key, IVec, Text)).
+-define(CRYPTO_BLOCK_DECRYPT(Key, IVec, Text),
+  crypto:block_decrypt(des_cbc, Key, IVec, Text)).
+-else.
+-define(CRYPTO_BLOCK_ENCRYPT(Key, IVec, Text),
+  crypto:des_cbc_encrypt(Key, IVec, Text)).
+-define(CRYPTO_BLOCK_DECRYPT(Key, IVec, Text),
+  crypto:des_cbc_decrypt(Key, IVec, Text)).
+-endif.
+
 phrase() -> atom_to_list(erlang:get_cookie()).
 
 encrypt(Data) -> encrypt(phrase(),Data).
@@ -15,17 +33,17 @@ encrypt(Data) -> encrypt(phrase(),Data).
 encrypt(Phrase,Data) ->
   assert_crypto(),
   {Key,Ivec} = make_key(Phrase),
-  crypto:des_cbc_encrypt(Key,Ivec,pad(Data)).
+  ?CRYPTO_BLOCK_ENCRYPT(Key, Ivec, pad(Data)).
 
 decrypt(Data) -> decrypt(phrase(),Data).
 
 decrypt(Phrase,Data) ->
   assert_crypto(),
   {Key,Ivec} = make_key(Phrase),
-  unpad(crypto:des_cbc_decrypt(Key,Ivec,Data)).
+  unpad(?CRYPTO_BLOCK_DECRYPT(Key, Ivec, Data)).
 
 make_key(Phrase) ->
-  <<Key:8/binary,Ivec:8/binary>> = crypto:md5(Phrase),
+  <<Key:8/binary,Ivec:8/binary>> = ?CRYPTO_HASH(Phrase),
   {Key,Ivec}.
 
 pad(Term) ->


### PR DESCRIPTION
When compiling with R16B02 the following deprecation warnings were
encountered:

```
src/prf_crypto.erl:36: Warning: crypto:des_cbc_encrypt/3 is deprecated and will be removed in in a future release; use crypto:block_encrypt/4
src/prf_crypto.erl:43: Warning: crypto:des_cbc_decrypt/3 is deprecated and will be removed in in a future release; use crypto:block_decrypt/4
src/prf_crypto.erl:46: Warning: crypto:md5/1 is deprecated and will be removed in in a future release; use crypto:hash/2
```

Since I use `warnings_as_errors` erlc option I needed to work around these
deprecation warnings for newer versions of Erlang (R16B+, I believe). I did
this using a `rebar.config.script` and the Erlang preprocessor's `-ifdef`
construct. Therefore, it should work for previous versions as well as newer
versions of Erlang.

This does make one assumption, an assumption I believe to be "safe", but
worth noting anyway. It assumes that if `crypto:block_encrypt/4` is exported 
from the `crypto` module that `crypto:block_decrypt/4` will also be exported.

Happy to amend that shortcut if necessary.
