### PR TITLE
append messages when use print_file option instead of rewriting file

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -368,7 +368,7 @@ mk_out(#cnf{print_re=RE,print_file=File}) ->
 
 get_fd("") -> standard_io;
 get_fd(FN) ->
-  case file:open(FN,[write]) of
+  case file:open(FN,[append]) of
     {ok,FD} -> FD;
     _ -> throw({cannot_open,FN})
   end.


### PR DESCRIPTION
Current version of redbug rewrites the entire file with the latest message. At least it is so on Mac OS.
In my PR I just changed open file option from write to append.
