### PR TITLE
Handle simple atoms (registered names) as send targets

### DIFF
--- a/src/redbug.erl
+++ b/src/redbug.erl
@@ -395,7 +395,10 @@ mk_outer(#cnf{print_depth=Depth,print_msec=MS} = Cnf) ->
       end
   end.
 
-to_str({Pid,Reg}) -> flat("~w(~p)",[Pid,Reg]).
+to_str({Pid,Reg}) ->
+  flat("~w(~p)",[Pid,Reg]);
+to_str(RegisteredName) ->
+  flat("~p", [RegisteredName]).
 
 mk_out(#cnf{print_re=RE,print_file=File}) ->
   FD = get_fd(File),


### PR DESCRIPTION
When tracing `send` from all processes I ran into this failure:

```
=ERROR REPORT==== 6-Mar-2015::08:39:45 ===
Error in process <0.125.0> on node 'yzremote@Thunder' with exit value: {function_clause,[{redbug,to_str,[global_name_server],[{file,"src/redbug.erl"},{line,398}]},{redbug,'-mk_outer/1-fun-3-',5,[{file,"src/redbug.erl"},{line,391}]},{redbug,'-wrap_print_fun/1-fun-0-',3,[{file,"src/redbug.erl"},{line...
```

`to_str` can be called with an atom such as `global_name_server`. Handle that case (or any other oddballs).