### PR TITLE
Compatibility with Erlang 18

### DIFF
--- a/src/prf.erl
+++ b/src/prf.erl
@@ -45,7 +45,7 @@ ticker_even()-> erlang:start_timer(incr(?TICK,0), self(),{tick}).
 ticker_odd() -> erlang:start_timer(incr(?TICK,?TICK div 2), self(),{tick}).
 
 incr(Tick,Offset) ->
-    {_, Sec, Usec} = now(),
+    {_, Sec, Usec} = erlang:timestamp(),
     Skew = Tick div 4,
     Tick+Skew-((round(Sec*1000+Usec/1000)-Offset+Skew) rem Tick).
 

--- a/src/prfPrc.erl
+++ b/src/prfPrc.erl
@@ -61,8 +61,8 @@ init_cst() ->
 
 get_info(Cst) ->
   case Cst#cst.max_procs < erlang:system_info(process_count) of
-    true -> {now(),[]};
-    false-> {now(),[{P,pid_info(P,?SORT_ITEMS)}||P<-lists:sort(processes())]}
+    true -> {erlang:timestamp(),[]};
+    false-> {erlang:timestamp(),[{P,pid_info(P,?SORT_ITEMS)}||P<-lists:sort(processes())]}
   end.
 
 %%% Dreds, Dmems, Mems and Msgqs are sorted lists of pids
@@ -73,7 +73,7 @@ select(Cst = #cst{old_info={Then,Olds}},{Now,Curs},Items) ->
   {DredL,DmemL,MemL,MsgqL} = topl(Olds,Curs,outf(Then,Now,Items),empties()),
   PidInfo = lists:usort([I || {_,I} <-lists:append([DredL,DmemL,MemL,MsgqL])]),
   [{node,node()},
-   {now,now()},
+   {now,erlang:timestamp()},
    {dreds,e1e2(DredL)},
    {dmem,e1e2(DmemL)},
    {mem,e1e2(MemL)},

--- a/src/prfSys.erl
+++ b/src/prfSys.erl
@@ -24,7 +24,7 @@
 %%
 %% tag                  [unit]    source
 %% node                 [atom()]  erlang:node()
-%% now                  [now()]   erlang:now()
+%% now                  [now()]   erlang:timestamp()
 %% procs                [count]   erlang:system_info(process_count)
 %% context_switches     [count/s] erlang:statistics(context_switches)
 %% gcs                  [count/s] erlang:statistics(garbage_collection)
@@ -62,7 +62,7 @@
 -export([collect/1,config/2]).
 
 -record(cst,{strategy=strategy(), node=node(), total_ram=0, cores=1,
-             cache=[], now=now()}).
+             cache=[], now=erlang:timestamp()}).
 
 -define(RATES,[context_switches,gcs,gc_reclaimed,io_in,io_out,reductions,
                user,nice,kernel,idle,iowait,
@@ -90,7 +90,7 @@ stats() ->
   {Reds,_} = erlang:statistics(reductions),
   RunQ = erlang:statistics(run_queue),
 
-  [{now, now()},
+  [{now,erlang:timestamp()},
    {procs,Procs},
    {context_switches,Ctxt},
    {gcs,GCs},

--- a/src/prfTrc.erl
+++ b/src/prfTrc.erl
@@ -22,7 +22,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% runs in the prfTarg process
 
-collect(LD) -> {LD, {?MODULE, {tick,now()}}}.
+collect(LD) -> {LD, {?MODULE, {tick,erlang:timestamp()}}}.
 
 config(LD,{start,Conf}) -> start(Conf),LD;
 config(LD,{stop,Args}) -> stop(Args),LD;
@@ -416,7 +416,7 @@ flush_time_count({MFA,_MatchSpec,Flags},Where) ->
   Where ! lists:foldl(fun(Flag,A)-> time_count(MFA,Flag,A) end,[],Flags).
 
 time_count(MFA,Flag,A) when Flag == call_count; Flag == call_time ->
-  [{Flag,{MFA,element(2,erlang:trace_info(MFA,Flag))},[],ts(now())}|A];
+  [{Flag,{MFA,element(2,erlang:trace_info(MFA,Flag))},[],ts(erlang:timestamp())}|A];
 time_count(_,_,A) ->
   A.
 

--- a/src/sherk_prof.erl
+++ b/src/sherk_prof.erl
@@ -18,12 +18,12 @@ go(Msg, Seq, State)          -> handler(Msg) ! {msg,Seq,Msg}, State.
 init() ->
   ?log([{starting,?MODULE}]),
   sherk_ets:new(sherk_prof),
-  {start,now()}.
+  {start,erlang:timestamp()}.
 
 terminate(Seq,{start,Start}) ->
   ?log([{finishing,sherk_prof},
         {seq,Seq},
-        {time,timer:now_diff(now(),Start)/1000000},
+        {time,timer:now_diff(erlang:timestamp(),Start)/1000000},
         {procs,length(ets:match(sherk_prof,{{handler,'$1'},'_'}))}]),
   TermFun = fun({{handler,_},Pid},_) -> Pid ! quit; (_,_) -> ok end,
   ets:foldl(TermFun,[],sherk_prof).

--- a/src/watchdog.erl
+++ b/src/watchdog.erl
@@ -395,7 +395,7 @@ make_report(Trigger,LD) ->
   reporter(Trigger,LD#ld.prfData).
 
 reporter(Trigger,TriggerData) ->
-  {?MODULE,node(),now(),Trigger,TriggerData}.
+  {?MODULE,node(),erlang:timestamp(),Trigger,TriggerData}.
 
 expand_ps([])                         -> [];
 expand_ps([{T,P}|Es]) when is_pid(P)  -> pii({T,P})++expand_ps(Es);


### PR DESCRIPTION
http://www.erlang.org/doc/apps/erts/time_correction.html#id76978

```
[hanyuu] ~/tmp/eper % make
==> eper (compile)
Compiled src/redbug_eunit.erl
Compiled src/gperfConsumer.erl
Compiled src/eper.erl
Compiled src/sherk_tree.erl
Compiled src/gen_serv.erl
Compiled src/gperf.erl
Compiled src/logReader.erl
Compiling src/sherk_prof.erl failed:
src/sherk_prof.erl:21: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang"
 chapter of the ERTS User's Guide for more information.
src/sherk_prof.erl:26: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang"
 chapter of the ERTS User's Guide for more information.
ERROR: compile failed while processing /home/mayoi/tmp/eper: rebar_abort
Makefile:8: recipe for target 'compile' failed
make: *** [compile] Error 1
```