### PR TITLE
Ku fresh upstream 0.92

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Makefile.in
 /doc/edoc-info
 config*
 *beam
+.local_dialyzer_plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: erlang
 
 notifications:
-  email: false
+  webhooks: http://basho-engbot.herokuapp.com/travis?key=2a0d2be54652e014d73f3431754de1f6136f2182
+  email: eng@basho.com
 
 otp_release:
   - 18.0

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,5 @@ release_patch: test
 	./bin/release.sh patch
 
 release: relase_patch
+
+include tools.mk

--- a/src/eper.app.src
+++ b/src/eper.app.src
@@ -1,7 +1,7 @@
 {application, eper,
  [
   {description, "Erlang Performance and Debugging Tools"},
-  {vsn, "0.92.0"},
+  {vsn, git},
   {registered, []},
   {applications, [kernel,stdlib]}
  ]}.

--- a/tools.mk
+++ b/tools.mk
@@ -28,11 +28,11 @@ endif
 
 dialyzer: ${PLT} ${LOCAL_PLT}
 	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
-ifeq (,$(wildcard $(LOCAL_PLT)))
-	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin
-else
-	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin
-endif
+	@if [ -f $(LOCAL_PLT) ]; then \
+		dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin; \
+	else \
+		dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin; \
+	fi
 
 cleanplt:
 	@echo 

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,45 @@
+test: compile
+	./rebar eunit skip_deps=true
+
+docs:
+	./rebar doc skip_deps=true
+
+PLT ?= $(HOME)/.riak_combo_dialyzer_plt
+LOCAL_PLT = .local_dialyzer_plt
+DIALYZER_FLAGS ?= -Wunmatched_returns
+
+${PLT}: compile
+ifneq (,$(wildcard $(PLT)))
+	dialyzer --check_plt --plt $(PLT) --apps $(DIALYZER_APPS) && \
+		dialyzer --add_to_plt --plt $(PLT) --output_plt $(PLT) --apps $(DIALYZER_APPS) ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(PLT) --apps $(DIALYZER_APPS); test $$? -ne 1
+endif
+
+${LOCAL_PLT}: compile
+ifneq (,$(wildcard deps/*))
+ifneq (,$(wildcard $(LOCAL_PLT)))
+	dialyzer --check_plt --plt $(LOCAL_PLT) deps/*/ebin  && \
+		dialyzer --add_to_plt --plt $(LOCAL_PLT) --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+endif
+endif
+
+dialyzer: ${PLT} ${LOCAL_PLT}
+	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
+ifeq (,$(wildcard $(LOCAL_PLT)))
+	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin
+else
+	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin
+endif
+
+cleanplt:
+	@echo 
+	@echo "Are you sure?  It takes several minutes to re-build."
+	@echo Deleting $(PLT) and $(LOCAL_PLT) in 5 seconds.
+	@echo 
+	sleep 5
+	rm $(PLT)
+	rm $(LOCAL_PLT)
+


### PR DESCRIPTION
Current develop branch has been too much diverse from latest 0.92 eper code. This pull request does:

- get rid of stale Basho-original modifications
- update to 0.92
- add necessary Basho-only modifications including

 - introduce tools.mk and related Makefile ponies.
 - modify `eper.app.src` `vsn` to git-originated
 - Chat bot notification

[Comparison between current head tag of develop branch with massamanet/eper master](https://github.com/massemanet/eper/compare/master...basho:7222eca) will let you see all Basho-original modifications. This supersedes #11 and #12.