### PR TITLE
Ensure that prfTime is loaded on the target node

### DIFF
--- a/src/prfTarg.erl
+++ b/src/prfTarg.erl
@@ -36,7 +36,7 @@ assert(Node,Collectors) ->
 
 assert_loaded(Node,Collectors) ->
   lists:foreach(fun(M) -> ass_loaded(Node,M) end,
-                [prf,prf_crypto,?MODULE|Collectors]).
+                [prf,prf_crypto,prfTime,?MODULE|Collectors]).
 
 ass_loaded(nonode@nohost,Mod) -> {module,Mod}=c:l(Mod);
 ass_loaded(Node,Mod) ->


### PR DESCRIPTION
prfTime can be called on the target node, so it needs to be loaded there.

Without this change, running redbug from the command line fails for me with this error:

```
09:32:57.749 [error] Error in process <0.845.0> on node 'foo@127.0.0.1' with exit value: {undef,[{prfTime,ts,[],[]},{prf,incr,2,[{file,"src/prf.erl"},{line,48}]},{prf,ticker_odd,0,[{file,"src/prf.erl"},{line,45}]},{prfTarg,init,0,[{file,"src/prfTarg.erl"},{line,99}]}]}
```