### PR TITLE
Quote trace patterns in redbug command line tool

### DIFF
--- a/priv/bin/redbug
+++ b/priv/bin/redbug
@@ -18,7 +18,6 @@ usage(){
 }
 
 VSN=""
-XTRA=""
 echo=""
 node=""
 
@@ -55,13 +54,14 @@ while [ -n "$1" ]
           if [ -z "$node" ]; then
               node=$1
           fi
-          XTRA=" $XTRA $1"
+          # Let's hold on to the remaining arguments in $@.
+          break
           ;;
   esac
   shift
 done
 
-if [ -z "$XTRA" ]; then usage; fi
+if [ -z "$1" ]; then usage; fi
 
 PATHS="-pa $self/ebin"
 # If the node name contains a dot after the @ sign, it is a long name,
@@ -76,6 +76,6 @@ name="redbug_"$$
 DISTR="-noshell -hidden $name_option $name $cookie $nettick"
 START="-run redbug unix"
 
-$echo erl $VSN $DISTR $PATHS $START $XTRA
+$echo erl $VSN $DISTR $PATHS $START "$@"
 
 if [ "$?" -eq "1" ]; then usage; fi


### PR DESCRIPTION
This preserves spaces in trace pattern passed on the command line, such
as:

redbug foo@127.0.0.1 "foo:bar -> return"

Without this change, the trace pattern would have been broken up by the
shell script, and the only way to write that pattern would be without
spaces, "foo:bar->return".  While doable, it's unintuitive, especially
as the part before "->" gets interpreted correctly, and you get a trace
that shows function calls but no return values.