### PR TITLE
Don't fail if 'locals' chunk is missing

### DIFF
--- a/src/prfTrc.erl
+++ b/src/prfTrc.erl
@@ -136,8 +136,12 @@ locals(M) ->
   case code:which(M) of
     preloaded -> [];
     F ->
-      {ok,{M,[{locals,Locals}]}} = beam_lib:chunks(F,[locals]),
-      Locals
+      case beam_lib:chunks(F,[locals]) of
+        {ok,{M,[{locals,Locals}]}} ->
+          Locals;
+        {error, beam_lib, {missing_chunk, _, _}} ->
+          []
+      end
   end.
 
 globals(M) ->


### PR DESCRIPTION
If the beam file has been stripped with beam_lib:strip/1, the 'locals'
chunk ("LocT") will be missing.  In that case, keep going: we'll only
lose the ability to trace local functions.