### PR TITLE
Make sure watchdog runs asynchronously + some minor bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ xref: all
 	@$(REBAR) xref
 
 dialyze: all ~/.dialyzer_plt
-	dialyzer -Wno_return -nn --plt ~/.dialyzer_plt --src src
+	dialyzer -Wno_return -nn --plt ~/.dialyzer_plt ebin
 
 ~/.dialyzer_plt:
 	- dialyzer -nn --output_plt ~/.dialyzer_plt --build_plt \

--- a/src/watchdog.erl
+++ b/src/watchdog.erl
@@ -539,7 +539,7 @@ mk_log(Type,FN) ->
       close_log_file(FD);
      (reset,_) ->
       close_log_file(FD),
-      mk_log(text,FN);
+      mk_log(Type,FN);
      (send,Term)->
       send_log_term(Type,FD,Term)
   end.


### PR DESCRIPTION
There are two small bug fixes and two important changes in this PR:

* Reporting user data to watchdog shall be asynchronous.
* The watchdog process shall not call process/port info on its own, as these functions may block. This means a `sysMon` report about a badly behaved process may block sending all other data to subscribers.