### PR TITLE
Start network subsystem

### DIFF
--- a/src/prfDog.erl
+++ b/src/prfDog.erl
@@ -178,6 +178,8 @@ acceptor_loop(ListenSock) ->
 -include_lib("eunit/include/eunit.hrl").
 
 t0_test() ->
+  os:cmd("epmd -daemon"),
+  net_kernel:start([testname, shortnames]),
   Port = 16#dada,
   Secret = "PWD",
   prf:start (dogC,node(),dogConsumer,node()),


### PR DESCRIPTION
Ensure that network subsystem is started in tests where necessary. So node() will return something sane (not a bogus value 'nonode@nohost').

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
